### PR TITLE
Fix RabbitMQ EPMD process owner

### DIFF
--- a/deployment_scripts/puppet/modules/plugin_zabbix/files/import/Template_App_OpenStack_RabbitMQ_ha.xml
+++ b/deployment_scripts/puppet/modules/plugin_zabbix/files/import/Template_App_OpenStack_RabbitMQ_ha.xml
@@ -106,7 +106,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>proc.num[,root,,bin/epmd]</key>
+                    <key>proc.num[,rabbitmq,,bin/epmd]</key>
                     <delay>30</delay>
                     <history>90</history>
                     <trends>365</trends>


### PR DESCRIPTION
After successful deployment of OpenStack in HA mode, Zabbix gives false alarm on RabbitMQ EPMD process : this PR fixes the owner of the EPMD process.
