### PR TITLE
Adding support for MOS 9.0 configurable hostnames.

### DIFF
--- a/deployment_scripts/puppet/manifests/agent.pp
+++ b/deployment_scripts/puppet/manifests/agent.pp
@@ -19,11 +19,9 @@ $primary_controller_nodes      = get_nodes_hash_by_roles($network_metadata, ['pr
 $controllers                   = get_nodes_hash_by_roles($network_metadata, ['primary-controller', 'controller'])
 $controller_internal_addresses = get_node_to_ipaddr_map_by_network_role($controllers, 'management')
 $controller_nodes              = ipsort(values($controller_internal_addresses))
-$hostinfo                      = $network_metadata['nodes'][$::hostname]
-$netinfo                       = $hostinfo['network_roles']
-$internal_address              = $netinfo['management']
-$public_address                = $netinfo['ex']
-$swift_address                 = $netinfo['storage']
+$internal_address              = $::ipaddress_br_mgmt
+$public_address                = $::ipaddress_br_ex
+$swift_address                 = $::ipaddress_br_storage
 
 if $fuel_version < 8.0 {
   $cur_node_roles = node_roles(hiera_array('nodes'), hiera('uid'))


### PR DESCRIPTION
In MOS 9.0 users can set the hostname of their node, but the hiera
in /etc/fuel/cluster/*/astute.yaml
still uses the orginal node name such as node-1 in the structure.

For example under
nodes:
    node-1:
      fqdn: dl360g7-72.mydomain.com
      name: dl360g7-72
      network_roles:
        admin/pxe: 10.20.122.18

When the zabbix agent.pp tries to parse the network_roles hash it uses
the fact $::hostname, which may be different from node-1.

To resolve this, the network ip details can be found by using specific
facts i.e.

$internal_address              = $::ipaddress_br_mgmt
$public_address                = $::ipaddress_br_ex
$swift_address                 = $::ipaddress_br_storage
