### PR TITLE
bumped PHP5_VERSION to 5.5.9+dfsg-1ubuntu4.21

### DIFF
--- a/pre_build_hook
+++ b/pre_build_hook
@@ -29,7 +29,7 @@ function download {
     done
 }
 
-PHP5_VERSION="5.5.9+dfsg-1ubuntu4.20"
+PHP5_VERSION="5.5.9+dfsg-1ubuntu4.21"
 ZBX_VERSION="2.4.8-1+trusty"
 
 download deb http://repo.zabbix.com/zabbix/2.4/ubuntu/pool/main/z/zabbix/zabbix-agent_${ZBX_VERSION}_amd64.deb \


### PR DESCRIPTION
Building fails because the old PHP5 version doesn't exist in the Ubuntu repos